### PR TITLE
chore: :arrow_up: upgrade to AGP 9.2.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,7 +1,8 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     alias(libs.plugins.kotlin.compose.compiler)
     alias(libs.plugins.androidApplication)
-    alias(libs.plugins.jetbrainsKotlinAndroid)
     alias(libs.plugins.ksp)
     alias(libs.plugins.daggerHiltAndroid)
     alias(libs.plugins.kover)
@@ -10,13 +11,13 @@ plugins {
 
 android {
     namespace = "ar.edu.unlam.mobile.scaffolding"
-    compileSdk = 35
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "ar.edu.unlam.mobile.scaffolding"
         minSdk = 24
         //noinspection EditedTargetSdkVersion
-        targetSdk = 35
+        targetSdk = 37
         versionCode = 1
         versionName = "1.0"
 
@@ -39,8 +40,10 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
-    kotlinOptions {
-        jvmTarget = "17"
+    kotlin {
+        compilerOptions {
+            jvmTarget = JvmTarget.JVM_17
+        }
     }
     buildFeatures {
         compose = true
@@ -63,6 +66,10 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.squareup.retrofit2.retrofit)
+    implementation(libs.squareup.retrofit2.converter.gson)
+    implementation(libs.coil.kt.coil3.coil.compose)
+    implementation(libs.coil.kt.coil3.coil.network.http)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
+buildscript {
+    dependencies {
+        // Raise AGP's built-in Kotlin (2.2.0) to the latest version AGP 9.2.0 supports (see libs.versions.toml).
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${libs.versions.kotlin.get()}")
+    }
+}
+
 plugins {
     alias(libs.plugins.androidApplication) apply false
-    alias(libs.plugins.jetbrainsKotlinAndroid) apply false
     alias(libs.plugins.daggerHiltAndroid) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.kover) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,19 +1,21 @@
 [versions]
 activityCompose = "1.9.2"
-agp = "8.10.1"
+agp = "9.2.0"
 coreKtx = "1.13.1"
 espressoCore = "3.6.1"
 junit = "4.13.2"
 junitVersion = "1.2.1"
-ksp = "2.0.20-1.0.24"
-kotlin = "2.0.20"
+ksp = "2.3.9"
+kotlin = "2.3.21"
 lifecycleRuntimeKtx = "2.8.6"
 material = "1.3.0"
 composeBom = "2024.09.02"
-dagger = "2.52"
+dagger = "2.59.2"
 androidXHilt = "1.2.0"
 kover = "0.7.6"
 ktlint = "12.1.0"
+retrofit = "3.0.0"
+coil = "3.4.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -34,6 +36,11 @@ androidx-hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navig
 google-dagger-hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "dagger" }
 google-dagger-hilt-android-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "dagger" }
 google-dagger-hilt-android-testing = { group = "com.google.dagger", name = "hilt-android-testing", version.ref = "dagger" }
+squareup-retrofit2-retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
+squareup-retrofit2-converter-gson = { group = "com.squareup.retrofit2", name = "converter-gson", version.ref = "retrofit" }
+coil-kt-coil3-coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }
+coil-kt-coil3-coil-network-http = { group = "io.coil-kt.coil3", name = "coil-network-okhttp", version.ref = "coil" }
+
 
 [plugins]
 kotlin-compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sat Apr 13 13:49:32 ART 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- AGP 8.x -> 9.2.0, Gradle wrapper 8.x -> 9.4.1
- Migrate to AGP 9 built-in Kotlin: drop org.jetbrains.kotlin.android plugin, move kotlin {} compilerOptions inside android {}
- Override built-in Kotlin (2.2.0) up to 2.3.21 via buildscript classpath
- Hilt/Dagger 2.52 -> 2.59.2 (AGP 9 support), KSP -> 2.3.9
- Pin Coil to 3.4.0 (3.5.0 forces kotlin-stdlib 2.4.0 that Hilt cannot read)